### PR TITLE
fix: ensure consistent footer year

### DIFF
--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -3,11 +3,12 @@
     <v-container>
       <v-row>
         <v-col class="text-center">
-          <div>&copy; {{ new Date().getFullYear() }} Juan Miguel Arias Mejias</div>
+          <div>&copy; {{ currentYear }} Juan Miguel Arias Mejias</div>
         </v-col>
       </v-row>
     </v-container>
   </v-footer>
 </template>
 <script setup lang="ts">
+const currentYear = new Date().getFullYear()
 </script>


### PR DESCRIPTION
## Summary
- compute footer copyright year once during setup to keep SSR/client output aligned

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Could not load @nuxtjs/seo. Is it installed?)

------
https://chatgpt.com/codex/tasks/task_b_68b609c20e54832fa1af814a7b81469a