### PR TITLE
Use runtime config for site URL and fix hydration warnings

### DIFF
--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -10,5 +10,9 @@
   </v-footer>
 </template>
 <script setup lang="ts">
-const currentYear = new Date().getFullYear()
+const currentYear = ref('')
+
+onMounted(() => {
+  currentYear.value = new Date().getFullYear()
+})
 </script>

--- a/app/composables/useSeo.ts
+++ b/app/composables/useSeo.ts
@@ -5,11 +5,13 @@ import type { SeoMetaOptions } from '~/types/seo'
  * Centralized composable to manage SEO meta tags and social data.
  */
 export function useSeo() {
+  const { public: { siteUrl } } = useRuntimeConfig()
+
   const setSeo = (opts: SeoMetaOptions) => {
     const title = ensureLength(opts.title, 60)
     const description = ensureLength(opts.description, 160)
     const image = opts.image || '/img/juanmiguelweb.png'
-    const url = opts.url || 'https://juanmiguel.dev'
+    const url = opts.url || siteUrl
     const siteName = opts.siteName || 'Juan Miguel - Portfolio'
 
     useHead({

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -22,10 +22,12 @@ import RecomendationsSection from '~/components/RecomendationsSection.vue'
 import TechStackSection from '~/components/TechStackSection.vue'
 import ContactForm from '~/components/ContactForm.vue'
 
+const { public: { siteUrl } } = useRuntimeConfig()
+
 const schema = {
   '@context': 'https://schema.org',
   '@type': ['Person', 'WebSite'],
   name: 'Juan Miguel',
-  url: 'https://juanmiguel.dev'
+  url: siteUrl
 }
 </script>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,6 +1,8 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 import vuetify from 'vite-plugin-vuetify'
 
+const siteUrl = process.env.NUXT_PUBLIC_SITE_URL || 'http://localhost:3000'
+
 export default defineNuxtConfig({
   compatibilityDate: '2025-07-15',
   devtools: { enabled: true },
@@ -14,6 +16,12 @@ export default defineNuxtConfig({
     '@nuxtjs/robots',
     '@nuxtjs/sitemap'
   ],
+
+  runtimeConfig: {
+    public: {
+      siteUrl
+    }
+  },
   
   image: {
     quality: 80,
@@ -29,7 +37,7 @@ export default defineNuxtConfig({
   },
   
   robots: {
-    sitemap: 'https://juanmiguel.dev/sitemap.xml'
+    sitemap: `${siteUrl}/sitemap.xml`
   },
   
   sitemap: {
@@ -58,7 +66,7 @@ export default defineNuxtConfig({
         { name: 'theme-color', content: '#ffffff' }
       ],
       link: [
-        { rel: 'canonical', href: 'https://juanmiguel.dev' },
+        { rel: 'canonical', href: siteUrl },
         { rel: 'icon', type: 'image/x-icon', href: '/favicon/favicon.ico' },
         { rel: 'icon', type: 'image/png', sizes: '16x16', href: '/favicon/favicon-16x16.png' },
         { rel: 'icon', type: 'image/png', sizes: '32x32', href: '/favicon/favicon-32x32.png' },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -16,7 +16,7 @@ export default defineNuxtConfig({
     '@nuxtjs/robots',
     '@nuxtjs/sitemap'
   ],
-
+  
   runtimeConfig: {
     public: {
       siteUrl
@@ -51,7 +51,10 @@ export default defineNuxtConfig({
     ssr: { noExternal: ['vuetify'] },
     plugins: [
       vuetify({ autoImport: true })
-    ]
+    ], 
+    define: {
+      __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: true
+    }
   },
   
   app: {

--- a/server/routes/sitemap.xml.ts
+++ b/server/routes/sitemap.xml.ts
@@ -1,9 +1,12 @@
 import { defineEventHandler, setHeader } from 'h3'
+import { useRuntimeConfig } from '#imports'
 
 /**
  * Basic dynamic sitemap generation for portfolio pages.
  */
 export default defineEventHandler((event) => {
+  const { public: { siteUrl } } = useRuntimeConfig()
+
   const urls = [
     '/',
     '/projects',
@@ -13,7 +16,7 @@ export default defineEventHandler((event) => {
 
   const body = `<?xml version="1.0" encoding="UTF-8"?>\n` +
     `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
-    urls.map(u => `  <url><loc>https://juanmiguel.dev${u}</loc></url>`).join('\n') +
+    urls.map(u => `  <url><loc>${siteUrl}${u}</loc></url>`).join('\n') +
     `\n</urlset>`
 
   setHeader(event, 'content-type', 'application/xml')


### PR DESCRIPTION
## Summary
- compute footer year on client to avoid SSR clock drift
- derive canonical URLs and sitemap domain from runtime config
- reference runtime config site URL in SEO utilities and schema

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68b62f3702c8832fb44dfbc6c89f89c1